### PR TITLE
fix: controlled dialog close behavior with Radix UI

### DIFF
--- a/app/(routes)/Dashboard/_components/AddNewInterview.jsx
+++ b/app/(routes)/Dashboard/_components/AddNewInterview.jsx
@@ -75,7 +75,7 @@ function AddNewInterview() {
 
 
             </div>
-            <Dialog open={openDialog}>
+            <Dialog open={openDialog} onOpenChange={setOpenDialog}>
                 <DialogContent className="max-w-2xl">
                     <DialogHeader>
                         <DialogTitle className='text-2xl'>Tell us more about your Business </DialogTitle>


### PR DESCRIPTION
This PR fixes an issue where the <DialogPrimitive.Close> (X button) and backdrop click did not close the dialog when using a controlled Dialog component from Radix UI.

Changes made:

- Added onOpenChange={setOpenDialog} to the <Dialog> component to sync internal state with the external openDialog boolean.

Impact:

The dialog can now be closed via:

- Clicking the X icon

- Clicking outside the dialog

- Pressing Escape

- Manually calling setOpenDialog(false) on Cancel/Submit