### PR TITLE
Add dark mode toggle

### DIFF
--- a/app/(routes)/Path/page.jsx
+++ b/app/(routes)/Path/page.jsx
@@ -47,9 +47,9 @@ const page = () => {
   {/* <img src='/path/side.gif' className='absolute mt-[10rem] -z-10 h-screen w-screen'/> */}
   <div className="max-w-screen px-4 py-8 sm:px-6 sm:py-12 lg:px-8 lg:py-16">
     <div className="max-w-xl">
-      <h2 className="text-3xl font-bold sm:text-4xl">Skills of Entrepreneurship</h2>
+      <h2 className="text-3xl font-bold sm:text-4xl dark:text-gray-100">Skills of Entrepreneurship</h2>
 
-      <p className="mt-4 text-gray-800">
+      <p className="mt-4 text-gray-700 dark:text-gray-200">
       Master essential skills like leadership, strategic thinking, and communication to drive entrepreneurial success.
       </p>
     </div>
@@ -59,7 +59,7 @@ const page = () => {
   items.map((item, i) => (
     <div
     key={i}
-    className="relative flex bg-gray-50 flex-col items-center border-2 border-neutral-900 h-[15rem] shadow-md hover:scale-105 "
+    className="relative flex bg-gray-50 flex-col items-center border-2 border-neutral-900 h-[15rem] shadow-md hover:scale-105 dark:bg-gray-800 dark:border-gray-200"
   >
     {/* Overlay GIF */}
     <a href={item.link} className={`absolute inset-0 bg-contain bg-center opacity-0 hover:opacity-100 transition-opacity duration-300`}
@@ -70,13 +70,13 @@ const page = () => {
       src={item.icon}
       alt={item.title}
     />
-    <a href={item.link} className="mt-4 text-xl font-bold text-gray-800">{item.title}</a>
-    <p className="mt-2 text-center text-gray-600">{item.description}</p>
+    <a href={item.link} className="mt-4 text-xl font-bold text-gray-800 dark:text-gray-100">{item.title}</a>
+    <p className="mt-2 text-center text-gray-600 dark:text-gray-300">{item.description}</p>
   </div>
   
   ))
 }
-  <div className="flex bg-gray-50 flex-col items-center b-2 border-neutral-900 h-[10rem] shadow-md">
+  <div className="flex bg-gray-50 flex-col items-center b-2 border-neutral-900 h-[10rem] shadow-md dark:bg-gray-800 dark:border-gray-200">
   <img
     className="w-full h-ull"
     src='/path/side.gif'

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -4,6 +4,8 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { Toaster } from "@/components/ui/sonner";
 import { Header } from "@/app/(routes)/Dashboard/_components/Header";
 import Nav from "./_Components/Navbar";
+import { ThemeProvider } from "@/components/theme-provider";
+import ThemeToggle from "@/components/ui/theme-toggle";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -15,13 +17,17 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <ClerkProvider>
-      <html lang="en">
+      <html lang="en" suppressHydrationWarning>
         <body className={inter.className}>
-          <Toaster/>
-          {/* <Nav/> */}
-          {children}
-        {/* <Header/> */}
-
+          <ThemeProvider>
+            <div className="fixed top-4 right-4 z-50">
+              <ThemeToggle />
+            </div>
+            <Toaster/>
+            {/* <Nav/> */}
+            {children}
+            {/* <Header/> */}
+          </ThemeProvider>
         </body>
       </html>
     </ClerkProvider>

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -9,7 +9,9 @@ import Nav from "./_Components/Navbar";
 import TextRevealByWord from "./_Components/Text-reveal";
 import { TrendingUp,ArrowUpFromDot  } from "lucide-react";
 import { Button } from "@/components/ui/button";
- 
+import { ThemeProvider } from "@/components/theme-provider";
+import ThemeToggle from "@/components/ui/theme-toggle";
+
 const products = [
   {
     title: "Market Understanding",
@@ -70,6 +72,11 @@ const page = () => {
       <>
        <Nav/>
 
+       <ThemeProvider>
+         <div className="fixed top-4 right-4 z-50">
+           <ThemeToggle />
+         </div>
+       </ThemeProvider>
 
 <section id='hero'
   className="relative bg-[url('/banner.jpg')] bg-cover bg-center bg-no-repeat opacity-90"

--- a/components/theme-provider.jsx
+++ b/components/theme-provider.jsx
@@ -1,0 +1,16 @@
+"use client";
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({ children }) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/components/ui/theme-toggle.jsx
+++ b/components/ui/theme-toggle.jsx
@@ -1,0 +1,17 @@
+"use client";
+import { useTheme } from "next-themes";
+import { Sun, Moon } from "lucide-react";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <button
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      className="p-2 rounded bg-gray-200 dark:bg-gray-700"
+      aria-label="Toggle theme"
+    >
+      {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </button>
+  );
+} 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aint",
       "version": "0.1.0",
       "dependencies": {
-        "@clerk/nextjs": "^5.1.5",
+        "@clerk/nextjs": "^5.7.5",
         "@google/generative-ai": "^0.12.0",
         "@neondatabase/serverless": "^0.9.3",
         "@radix-ui/react-collapsible": "^1.0.3",
@@ -69,14 +69,14 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-1.2.3.tgz",
-      "integrity": "sha512-tj812eTTn2ewXMgr4jwFjpqoXZRF2LMw9UBT+Nat0lmXw55sDA5ou2McLZ67e62WNZwbrCUa51MGKSBhrWnZcA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-1.14.1.tgz",
+      "integrity": "sha512-YlKMpiVo4UITw3sgA+9QrAFRILVOz5hgB1Zw180Y2LEZ5a+MdpX668vJKGh7riSweMN7JQvU2jlsKGRO+1bXDw==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "2.3.0",
-        "@clerk/types": "4.6.0",
-        "cookie": "0.5.0",
+        "@clerk/shared": "2.9.2",
+        "@clerk/types": "4.26.0",
+        "cookie": "0.7.0",
         "snakecase-keys": "5.4.4",
         "tslib": "2.4.1"
       },
@@ -91,13 +91,13 @@
       "license": "0BSD"
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.2.4.tgz",
-      "integrity": "sha512-TaSjf3pdxUKQIDmwi6JkJDVGwHbs7pTeiwEr2/JksMrQnW6zMIutsEhJfW10dY1hOwJeDoSxGCkHw+7Br2rktw==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.12.0.tgz",
+      "integrity": "sha512-3Lr2QazCm5R6ZLbu7wM+d5YwCElrAoX00OBWcKqjPYaWDJCCmEYN6LJbLzOTYQ8QT1J1ZIed85/lKa+q2aD1aA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "2.3.0",
-        "@clerk/types": "4.6.0",
+        "@clerk/shared": "2.9.2",
+        "@clerk/types": "4.26.0",
         "tslib": "2.4.1"
       },
       "engines": {
@@ -115,17 +115,17 @@
       "license": "0BSD"
     },
     "node_modules/@clerk/nextjs": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-5.1.5.tgz",
-      "integrity": "sha512-q/4PvWrIt4cO9dwgUyJ/gN/fWbS2GnfKK7j32cn6LBObVqUIiQ+J5Q+lp75q+tzIHyxFJx+MNNTnFif2OrvV6A==",
+      "version": "5.7.5",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-5.7.5.tgz",
+      "integrity": "sha512-hfH4IiKcDT9LlqSOlNHZoYfX6iF4lBqPXf/KwnILCX/0+MVYaotb30FwWXkcHI2jZgcvumlQTOq8Gv5KugnihA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "1.2.3",
-        "@clerk/clerk-react": "5.2.4",
-        "@clerk/shared": "2.3.0",
-        "@clerk/types": "4.6.0",
+        "@clerk/backend": "1.14.1",
+        "@clerk/clerk-react": "5.12.0",
+        "@clerk/shared": "2.9.2",
+        "@clerk/types": "4.26.0",
         "crypto-js": "4.2.0",
-        "path-to-regexp": "6.2.2",
+        "server-only": "0.0.1",
         "tslib": "2.4.1"
       },
       "engines": {
@@ -144,13 +144,13 @@
       "license": "0BSD"
     },
     "node_modules/@clerk/shared": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-2.3.0.tgz",
-      "integrity": "sha512-V/49MoOrALzpu0BbhYDCcKQYIjrHnhRa7QFho9+4wm94oCJgc9j3N5wxndJwj3Ur/fmIyBnjwMzDAT2nZZj47g==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-2.9.2.tgz",
+      "integrity": "sha512-vRMDj13Pv9n8Pf+f8P40AvqJ8QEq348qUxUVIf17vn9R3/toicrQOY/Q6qsrAS8KXY9+ZnyTafJa+VFK+6iEFA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@clerk/types": "4.6.0",
+        "@clerk/types": "4.26.0",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.5",
         "std-env": "^3.7.0",
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@clerk/types": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.6.0.tgz",
-      "integrity": "sha512-kowqVGqLfu0Zl2Pteum70MfkGHqBUoHHeR+u2+yWVl1lKHLCiyY1u8ntYBEIolAylBaQNDuRzxyMIDPSxjPE8g==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.26.0.tgz",
+      "integrity": "sha512-VGcrQz/XpCiGbpIIzKVwWw4nLorzKnIP1IAemj1xt/80ULcdEZCncwhas6PoYBBsl1W55A1SwP9B/pEs0nmkCw==",
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.1"
@@ -2241,9 +2241,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.0.tgz",
+      "integrity": "sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2309,6 +2309,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-gpu": {
@@ -3255,12 +3264,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-      "license": "MIT"
-    },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -3856,6 +3859,12 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3960,9 +3969,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
-      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "license": "MIT"
     },
     "node_modules/streamsearch": {
@@ -4136,16 +4145,16 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
-      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
       "license": "MIT",
       "dependencies": {
-        "client-only": "^0.0.1",
-        "use-sync-external-store": "^1.2.0"
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
       },
       "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tailwind-merge": {
@@ -4390,12 +4399,12 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -11,17 +11,16 @@
     "db:kits": "npx drizzle-kit studio"
   },
   "dependencies": {
-    "@react-three/drei": "9.75.0",
-    "@react-three/fiber": "8.13.3",
-    "@types/three": "0.152.1",
-    "three": "0.153.0",
-    "@clerk/nextjs": "^5.1.5",
+    "@clerk/nextjs": "^5.7.5",
     "@google/generative-ai": "^0.12.0",
     "@neondatabase/serverless": "^0.9.3",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
+    "@react-three/drei": "9.75.0",
+    "@react-three/fiber": "8.13.3",
     "@tabler/icons-react": "^3.6.0",
+    "@types/three": "0.152.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.31.2",
@@ -37,6 +36,7 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
+    "three": "0.153.0",
     "uuid": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary of changes for issue #9 

- **Added dark mode toggle:**  
  A toggle button is now available at the top-right corner of all pages.

- **Theme persistence:**  
  User’s theme preference is saved in `localStorage` and persists across sessions.

- **Skills of Entrepreneurship page updates:**  
  - Skill boxes now have proper dark backgrounds, borders, and text in dark mode.
  - Headings and subheadings are brighter and more readable in dark mode.

- **Consistency:**  
  All changes use Tailwind CSS `dark:` classes for styling.

https://github.com/user-attachments/assets/70239605-eea7-488a-bd88-eb5876241554

Closes #9 